### PR TITLE
Strip country code from languages to match server-side requirements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,7 @@
         "operator-linebreak": ["error", "before"],
         "padded-blocks": ["error", "never"],
         "prefer-arrow-callback": "off",
+        "prefer-destructuring": "off",
         "prefer-template": "off",
         "quote-props": "off",
         "quotes": ["error", "double"],

--- a/background.js
+++ b/background.js
@@ -1,10 +1,12 @@
 var googleTranslationBySlamId = "google-translation-by-slam";
 var fromLang = "auto";
 var toLang = browser.i18n.getUILanguage();
-// remove country code except for in zh-CN and zh-TW
-// (all other languages don't accept country code, as of Aug. 2020)
+// Remove country code except for in zh-CN and zh-TW
+// (All other languages don't accept country code, as of Aug. 2020)
 var ccLangs = ["zh-CN", "zh-TW"];
-if (toLang.includes("-") && !ccLangs.includes(toLang)) toLang = toLang.split("-")[0];
+if (toLang.includes("-") && !ccLangs.includes(toLang)) {
+    toLang = toLang.split("-")[0];
+}
 
 var goToGoogleTranslate = function(data) {
     var text = data.shift();

--- a/background.js
+++ b/background.js
@@ -5,7 +5,7 @@ var toLang = browser.i18n.getUILanguage();
 // (All other languages don't accept country code, as of Aug. 2020)
 var ccLangs = ["zh-CN", "zh-TW"];
 if (toLang.includes("-") && !ccLangs.includes(toLang)) {
-    toLang = toLang.split("-")[0];
+    [toLang] = toLang.split("-");
 }
 
 var goToGoogleTranslate = function(data) {

--- a/background.js
+++ b/background.js
@@ -1,6 +1,11 @@
 var googleTranslationBySlamId = "google-translation-by-slam";
 var fromLang = "auto";
 var toLang = browser.i18n.getUILanguage();
+// remove country code except for in zh-CN and zh-TW
+// (all other languages don't accept country code, as of Aug. 2020)
+var ccLangs = ["zh-CN", "zh-TW"];
+if (toLang.includes("-") && !ccLangs.includes(toLang)) toLang = toLang.split("-")[0];
+
 var goToGoogleTranslate = function(data) {
     var text = data.shift();
 

--- a/background.js
+++ b/background.js
@@ -1,11 +1,17 @@
 var googleTranslationBySlamId = "google-translation-by-slam";
 var fromLang = "auto";
 var toLang = browser.i18n.getUILanguage();
-// Remove country code except for in zh-CN and zh-TW
-// (All other languages don't accept country code, as of Aug. 2020)
-var ccLangs = ["zh-CN", "zh-TW"];
+
+/*
+ * Remove country code except for in zh-CN and zh-TW
+ * (All other languages don't accept country code, as of Aug. 2020)
+ */
+var ccLangs = [
+    "zh-CN",
+    "zh-TW"
+];
 if (toLang.includes("-") && !ccLangs.includes(toLang)) {
-    [toLang] = toLang.split("-");
+    toLang = toLang.split("-")[0];
 }
 
 var goToGoogleTranslate = function(data) {
@@ -39,9 +45,12 @@ browser.contextMenus.onClicked.addListener(function(info, tab) {
         return;
     }
 
-    var executing = browser.tabs.executeScript(tab.id, {
-        code: "window.prompt(\"Text to translate (" + fromLang + " -> " + toLang + ")?\");"
-    });
+    var executing = browser.tabs.executeScript(
+        tab.id,
+        {
+            code: "window.prompt(\"Text to translate (" + fromLang + " -> " + toLang + ")?\");"
+        }
+    );
 
     executing.then(goToGoogleTranslate);
 });

--- a/background.js
+++ b/background.js
@@ -10,6 +10,7 @@ var ccLangs = [
     "zh-CN",
     "zh-TW"
 ];
+
 if (toLang.includes("-") && !ccLangs.includes(toLang)) {
     toLang = toLang.split("-")[0];
 }


### PR DESCRIPTION
The only target languages that should have country codes are zh-CN and zh-TW.
This change will remove the country code from all other languages returned by getUILanguage.
Should fix #1